### PR TITLE
kitchen org policy tests

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -58,3 +58,15 @@ suites:
           backend: gcp
           controls:
             - gcp_perimeters
+  - name: orgpolicies
+    driver:
+      root_module_directory: test/fixtures/orgpolicies
+    verifier:
+      color: false
+      systems:
+        - name: inspec-gcp
+          backend: gcp
+          controls:
+            - gcp_compute_policy
+            - gcp_iam_policy
+            - gcp_policy

--- a/terraform/modules/orgpolicies/policies_gcp.tf
+++ b/terraform/modules/orgpolicies/policies_gcp.tf
@@ -17,7 +17,7 @@
 # Organizational Policies (applied at the folder level)
 #
 # These are the minimum policies
-# - Resource location: gcp.resourceLocations
+# - Resource location: constraints/gcp.resourceLocations
 #     - references of valid value groups: https://cloud.google.com/resource-manager/docs/organization-policy/defining-locations#value_groups     
 #
 # (Optional policies)

--- a/test/fixtures/orgpolicies/main.tf
+++ b/test/fixtures/orgpolicies/main.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# resource "random_string" "random_fldr" {
+#   length    = 4
+#   min_lower = 4
+#   special   = false
+# }
+
+data "google_folder" "fldr_trusted_test" {
+  folder              = var.trusted_folder_id
+  lookup_organization = false
+}
+
+# make a temporary trusted folder
+# resource "google_folder" "fldr_trusted_test" {
+#   display_name = format("eeee-%s-%s", var.folder_trusted, random_string.random_fldr.result)
+#   parent       = var.parent_env
+# }
+
+module "orgpolicies" {
+  source             = "../../../terraform/modules/orgpolicies"
+  folder_trusted     = google_folder.fldr_trusted_test.name
+  resource_locations = var.resource_locations
+
+  depends_on = [google_folder.fldr_trusted_test]
+}

--- a/test/fixtures/orgpolicies/outputs.tf
+++ b/test/fixtures/orgpolicies/outputs.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "trusted_folder" {
+  description = "Trust Folder where org policies are applied"
+  value       = google_folder.fldr_trusted_test.name
+}
+
+output "included_regions" {
+  description = "list of allowed regions where resources can be deployed"
+  value       = var.resource_locations
+}

--- a/test/fixtures/orgpolicies/variables.tf
+++ b/test/fixtures/orgpolicies/variables.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "trusted_folder_id" {
+  description = "Top level folder hosting PII data.  Format should be folder/1234567"
+  type        = string
+}
+
+variable "resource_locations" {
+  description = "The locations used in org policy to limit where resources can be provisioned"
+  type        = list(string)
+}
+
+variable "parent_env" {
+  description = "The parent env folder for trusted environment"
+  type        = string
+}

--- a/test/integration/orgpolicies/controls/gcp_compute_policies.rb
+++ b/test/integration/orgpolicies/controls/gcp_compute_policies.rb
@@ -1,0 +1,58 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+folder = attribute('trusted_folder')
+
+# constraints to validate
+vm_external_ip_access = 'constraint/compute.vmExternalIpAccess'
+skip_default_network_creation = 'constraints/compute.skipDefaultNetworkCreation'
+disable_serial_port_access = 'constraints/compute.disableSerialPortAccess'
+disable_serial_port_logging = 'constraints/compute.disableSerialPortLogging'
+require_os_login = 'constraints/compute.requireOsLogin'
+
+
+control 'gcp_compute_policy' do
+  title 'OrgPolicies module constraint tests for compute constraints'
+
+  describe google_organization_policy(organization_name: folder, constraint: vm_external_ip_access ) do
+    it { should exist }
+    its('constraint') { should eq vm_external_ip_access }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: skip_default_network_creation ) do
+    it { should exist }
+    its('constraint') { should eq skip_default_network_creation }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: disable_serial_port_access ) do
+    it { should exist }
+    its('constraint') { should eq disable_serial_port_access }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: disable_serial_port_logging ) do
+    it { should exist }
+    its('constraint') { should eq disable_serial_port_logging }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: require_os_login ) do
+    it { should exist }
+    its('constraint') { should eq require_os_login }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+end

--- a/test/integration/orgpolicies/controls/gcp_iam_policies.rb
+++ b/test/integration/orgpolicies/controls/gcp_iam_policies.rb
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+folder = attribute('trusted_folder')
+
+disable_sa_creation = 'constraints/iam.disableServiceAccountCreation'
+disable_sa_key_creation = 'constraints/iam.disableServiceAccountKeyCreation'
+auto_iam_grants_for_default_sa = 'constraints/iam.automaticIamGrantsForDefaultServiceAccounts'
+
+control 'gcp_iam_policy' do
+  title 'OrgPolicies module constraint tests for IAM constraints'
+
+  describe google_organization_policy(organization_name: folder, constraint: disable_sa_creation ) do
+    it { should exist }
+    its('constraint') { should eq disable_sa_creation }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: disable_sa_key_creation ) do
+    it { should exist }
+    its('constraint') { should eq disable_sa_key_creation }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+  describe google_organization_policy(organization_name: folder, constraint: auto_iam_grants_for_default_sa ) do
+    it { should exist }
+    its('constraint') { should eq auto_iam_grants_for_default_sa }
+    its('boolean_policy.enforced') { should be true }
+  end
+
+end
+
+

--- a/test/integration/orgpolicies/controls/gcp_policies.rb
+++ b/test/integration/orgpolicies/controls/gcp_policies.rb
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+folder = attribute('trusted_folder')
+included_regions =  attribute('included_regions')
+
+# constraints to validate
+resource_location = 'constraints/gcp.resourceLocations'
+
+control 'gcp_policy' do
+  title 'OrgPolicies module constraint tests for gcp constraints'
+
+  describe google_organization_policy(organization_name: folder, constraint: resource_location ) do
+    it { should exist }
+    its('constraint') { should eq resource_location }
+    its('list_policy.allowed_values') { should include included_regions }
+  end
+end

--- a/test/integration/orgpolicies/inspec.yml
+++ b/test/integration/orgpolicies/inspec.yml
@@ -1,0 +1,28 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: orgpolicies
+depends:
+  - name: inspec-gcp
+    git: https://github.com/inspec/inspec-gcp.git
+    tag: v1.7.0
+attributes:
+  - name: trusted_folder
+    required: true
+    type: string
+  - name: included_regions
+    required: true
+    type: array

--- a/test/setup_variables.sh
+++ b/test/setup_variables.sh
@@ -30,9 +30,21 @@ export DEPLOYMENT_PROJECT_ID=""
 # " elo-fldr-prod-trusted2"
 export PARENT_FOLDER=""
 
+# folder that has all the trusted projets (e.g folder/123456890)
+export TRUSTED_FOLDER_ID=""
+
+# Provide your billing account
+# gcloud beta billing accounts list
+# ABCDEF-234567-HIJKLM
+export BILLING_ACCOUNT=""  
+
 # Your organization ID
 # `glcoud organizations list`
 export ORGANIZATION_ID=""
+
+# Existing access policy ID number
+# 987654321
+export POLICY_NAME=""
 
 # Your project names defined in the terraform/terraform.template.tfvars file
 export PRJ_HIGH_TRUST_ANALYTICS=""
@@ -55,9 +67,10 @@ export POLICY_NAME=""
 # Kitchen-terraform variables
 export TF_VAR_organizations=${ORGANIZATION_ID}
 export TF_VAR_default_policy_name=${POLICY_NAME}
-export TF_VAR_terraform_sa_email=${IMPERSONATION_SA}
+export TF_VAR_terraform_sa_email=${TERRAFORM_SA}
 export TF_VAR_caip_compute_sa_email=${CAIP_COMPUTE_SA}
 export TF_VAR_billing_account=${BILLING_ACCOUNT}
+export TF_VAR_trusted_folder_id=${TRUSTED_FOLDER_ID}
 export TF_CLI_ARGS_apply="-var-file=$(pwd)/terraform/terraform.template.tfvars"
 export TF_CLI_ARGS_destroy="-var-file=$(pwd)/terraform/terraform.template.tfvars"
 
@@ -67,15 +80,18 @@ export TF_CLI_ARGS_destroy="-var-file=$(pwd)/terraform/terraform.template.tfvars
 echo ""
 echo "Environment setup with values:"
 echo "==================================================="
+echo "Billing account: ${BILLING_ACCOUNT:?}"
 echo "Deployment project ID: ${DEPLOYMENT_PROJECT_ID:?}"
 echo "Policy name: ${POLICY_NAME:?}"
-echo "Parent Folder: ${PARENT_FOLDER:?}"
+echo "Parent folder: ${PARENT_FOLDER:?}"
+echo "Trusted folder ID: ${TRUSTED_FOLDER_ID:?}"
 echo "Organization: ${ORGANIZATION_ID:?}"
+echo "Policy name: ${POLICY_NAME:?}"
 echo "Project high trust analytics: ${PRJ_HIGH_TRUST_ANALYTICS:?}"
 echo "Project high trust data: ${PRJ_HIGH_TRUST_DATA:?}"
 echo "Project high trust data ETL: ${PRJ_HIGH_TRUST_DATA_ETL:?}"
 echo "Project high trust kms: ${PRJ_HIGH_TRUST_KMS:?}"
-echo "Terraform Service Account: ${TERRAFORM_SA:?}"
+echo "Terraform service account: ${TERRAFORM_SA:?}"
 echo "CAIP compute Service Account: ${CAIP_COMPUTE_SA:?}"
 echo "==================================================="
 echo ""


### PR DESCRIPTION
- controls for compute
- controls for iam
- controls for gcp
- user needs to specify the folder created to hold all trusted data