### PR TITLE
eliminate high and medium findings from SCC/SHA

### DIFF
--- a/terraform/modules/firewall/main.tf
+++ b/terraform/modules/firewall/main.tf
@@ -45,8 +45,28 @@ resource "google_compute_firewall" "iap_fw" {
   direction     = "INGRESS"
   project       = var.project_id
   source_ranges = ["35.235.240.0/20"]
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"
+    ports    = ["22", "3389"]
+  }
+}
+
+resource "google_compute_firewall" "deny_egress" {
+  name               = "fw-deny-egress"
+  network            = var.vpc_name
+  priority           = 10000
+  direction          = "EGRESS"
+  project            = var.project_id
+  destination_ranges = ["0.0.0.0/0"]
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+
+  allow {
+    protocol = "all"
   }
 }

--- a/terraform/modules/notebooks/main.tf
+++ b/terraform/modules/notebooks/main.tf
@@ -91,6 +91,8 @@ resource "google_notebooks_instance" "caip_nbk_p_trusted" {
     notebook-disable-root      = "true"
     notebook-disable-downloads = "true"
     notebook-disable-nbconvert = "true"
+    serial-port-enable         = "FALSE"
+    block-project-ssh-keys     = "TRUE"
   }
 
   lifecycle {

--- a/test/integration/notebooks/controls/gcp_notebooks.rb
+++ b/test/integration/notebooks/controls/gcp_notebooks.rb
@@ -38,7 +38,11 @@ control 'gcp_notebooks' do
       its('metadata_values') { should include 'TRUE' }
       its('metadata_keys') { should include 'post-startup-script' }
       its('metadata_values') { should include script_name[0] }
-
+      its('metadata_keys') { should include 'serial-port-enable' }
+      its('metadata_values') { should include 'FALSE' }
+      its('metadata_keys') { should include 'block-project-ssh-keys' }
+      its('metadata_values') { should include 'TRUE' }
+     
       # TODO add additional checks
       #its('disks.disk_encryption_key.kms_key_name') { should be kms_key_name }
       #its('first_network_interface_nat_ip_exists'){ should_not exist }


### PR DESCRIPTION
- H: OPEN_FIREWALL - IAP port limits
- M: COMPUTE_PROJECT_WIDE_SSH_KEYS_ALLOWED: added metadata block
- M: FIREWALL_RULE_LOGGING_DISABLES: add log_config block to rules
- L: EGRESS_DENY_RULE_NOT_SET - add firewall rule