### PR TITLE
Updates some variable names and match md to guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,6 @@ export TF_VAR_project_trusted_data="your_data_project_id"
 export TF_VAR_project_trusted_kms="your_kms_project_id"
 export TF_VAR_default_policy_id = ${TF_VAR_org_id}  # access policy only accepts org_id
 export TF_VAR_vpc_perimeter_ip_subnetworks = "your_subnet_for_vpc_perimeter"
-export TF_VAR_caip_users = '["scientist1@example.com", "scientist2@example.com"]'
 export TF_VAR_confidential_groups = '["group:data-owners@example.com", "group:trusted-data-scientists@example.com"]'
 export TF_VAR_trusted_scientists = '["user:scientist1@example.com", "user:scientist2@example.com"]'
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ export TF_VAR_project_trusted_kms="your_kms_project_id"
 export TF_VAR_default_policy_id = ${TF_VAR_org_id}  # access policy only accepts org_id
 export TF_VAR_vpc_perimeter_ip_subnetworks = "your_subnet_for_vpc_perimeter"
 export TF_VAR_caip_users = '["scientist1@example.com", "scientist2@example.com"]'
-export TF_VAR_confid_users = '["group@example.com", "group2@example.com"]'
+export TF_VAR_confidential_groups = '["group:data-owners@example.com", "group:trusted-data-scientists@example.com"]'
 export TF_VAR_trusted_scientists = '["user:scientist1@example.com", "user:scientist2@example.com"]'
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ docker_run:
         -e TF_VAR_project_trusted_kms \
         -e TF_VAR_default_policy_id \
         -e TF_VAR_vpc_perimeter_ip_subnetworks \
-        -e TF_VAR_caip_users \
         -e TF_VAR_confidential_groups \
         -e TF_VAR_trusted_scientists \
 		-v "$(CURDIR)":/workspace \
@@ -70,7 +69,6 @@ docker_test_cleanup:
         -e TF_VAR_project_trusted_kms \
         -e TF_VAR_default_policy_id \
         -e TF_VAR_vpc_perimeter_ip_subnetworks \
-        -e TF_VAR_caip_users \
         -e TF_VAR_confidential_groups \
         -e TF_VAR_trusted_scientists \
 		-v "$(CURDIR)":/workspace \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ docker_run:
         -e TF_VAR_default_policy_id \
         -e TF_VAR_vpc_perimeter_ip_subnetworks \
         -e TF_VAR_caip_users \
-        -e TF_VAR_confid_users \
+        -e TF_VAR_confidential_groups \
         -e TF_VAR_trusted_scientists \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
@@ -71,7 +71,7 @@ docker_test_cleanup:
         -e TF_VAR_default_policy_id \
         -e TF_VAR_vpc_perimeter_ip_subnetworks \
         -e TF_VAR_caip_users \
-        -e TF_VAR_confid_users \
+        -e TF_VAR_confidential_groups \
         -e TF_VAR_trusted_scientists \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides an opinionated way to set up AI Platform Notebook in a 
 **This is not an officially supported Google product**
 
 ## Reference Architecture
-![Reference Architecture](diagrams/notebook_blueprint_arch.png)	   	
+![Reference Architecture](diagrams/notebook_blueprint_arch.png)
 
 
 The resources that this module will create are:
@@ -34,26 +34,26 @@ The resources that this module will create are:
 ## Prerequisites
 
 ### Prepare your admin workstation
-You can use Cloud Shell, a local machine or VM as your admin workstation 
+You can use Cloud Shell, a local machine or VM as your admin workstation
 
-#### 
+####
 [**Tools for Cloud Shell as your Admin workstation**](#tools-for-cloud-shell-as-your-admin-workstation)
 
 *   [Terraform >= 0.12.3](https://www.terraform.io/downloads.html)
 *   [Terraform Provider for GCP][terraform-provider-gcp] plugin v3.51
 
-#### 
+####
 [**Tools for a local workstation as your Admin workstation**](#tools-for-a-local-workstation-as-your-admin-workstation)
 
 *   [Cloud SDK (gcloud CLI)](https://cloud.google.com/sdk/docs/quickstarts)
 *   [Terraform >= 0.12.3](https://www.terraform.io/downloads.html)
 *   [Terraform Provider for GCP][terraform-provider-gcp] plugin v3.51
 
-#### 
-**Installation instructions for Tools for your environment** 
+####
+**Installation instructions for Tools for your environment**
 
 
-##### 
+#####
 [Install Cloud SDK](#install-cloud-sdk)
 
 
@@ -61,14 +61,14 @@ This is pre installed if you are using Cloud Shell
 
 The Google Cloud SDK is used to interact with your GCP resources. [Installation instructions](https://cloud.google.com/sdk/downloads) for multiple platforms are available online.
 
-##### 
+#####
 [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
 
 Terraform is used to automate the manipulation of cloud infrastructure. Its [installation instructions](https://www.terraform.io/intro/getting-started/install.html) are also available online.
 When configuring terraform for use with Google cloud create a service account as detailed in [Getting started with the google provider](https://www.terraform.io/docs/providers/google/guides/getting_started.html#adding-credentials)
 
 
-#### **Authentication** 
+#### **Authentication**
 
 After installing the gcloud SDK run gcloud init to set up the gcloud cli. When executing choose the correct region and zone
 
@@ -109,7 +109,7 @@ module "notebooks_blueprint_security" {
   trusted_private_network         = "projects/<shared-restricted-prj>/global/networks/<your_vpc>"
   trusted_private_subnet          = "projects/<shared-restricted-prj>/regions/<region>/subnetworks/<your_subnets_for_notebooks>"
   caip_users                      = ["trusted1@example.com", "trusted2@example.com"]
-  confid_users                    = ["group:admin@example.com", "group:trusted-users@example.com"]
+  confidential_groups             = ["group:data-owners@example.com", "group:trusted-data-scientists@example.com"]
   trusted_scientists              = ["user:trusted1@example.com", "user:trusted2@example.com"]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -166,9 +166,8 @@ Functional examples are included in the
 | resource\_locations | Regions where resource can be provisioned | `list(string)` | `[]` | yes |
 | vpc\_subnets\_projects\_allowed | list of projects with allowed vpc subnets for the notebooks; defined with the under constraint format (e.g. ["under:projects/project_id1", "under:projects/project_id2"]) | `list(string)` | `[]` | yes |
 | notebook\_key\_name | name to use to create a KMS/HSM key that protects pii data | `string` | `""` | yes |
-| caip\_users | The list of users that need an AI Platform Notebook (list of emails). | `list(string)` | `[]` | yes |
 | trusted\_scientists | The list of trusted scientists (in the form of user:scientist1@example.com) | `list(string)` | `[]` | yes |
-| confid\_users | The list of groups with privileged users that can access PII data. (ex: group@example.com) | `list(string)` | `[]` | yes |
+| confidentials\_groups | The list of groups with privileged users that can access PII data. (ex: group:trusted-data-scientists@example.com) | `list(string)` | `[]` | yes |
 | dataset\_id | BigQuery dataset ID with PII data that scientists need access | `string` | `""` | yes |
 | notebook\_name\_prefix | Prefix used in provisioning Notebooks in the higher trust boundary. | `string` | `"trusted-sample"` | no |
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ module "notebooks_blueprint_security" {
   project_trusted_kms             = "trusted-kms"
   trusted_private_network         = "projects/<shared-restricted-prj>/global/networks/<your_vpc>"
   trusted_private_subnet          = "projects/<shared-restricted-prj>/regions/<region>/subnetworks/<your_subnets_for_notebooks>"
-  caip_users                      = ["trusted1@example.com", "trusted2@example.com"]
   confidential_groups             = ["group:data-owners@example.com", "group:trusted-data-scientists@example.com"]
   trusted_scientists              = ["user:trusted1@example.com", "user:trusted2@example.com"]
 }

--- a/examples/standalone_example/main.tf
+++ b/examples/standalone_example/main.tf
@@ -44,6 +44,6 @@ module "notebook" {
   trusted_private_network   = var.trusted_private_network
   trusted_private_subnet    = var.trusted_private_subnet
   caip_users                = var.caip_users
-  confid_users              = var.confid_users
+  confidential_groups       = var.confidential_groups
   trusted_scientists        = var.trusted_scientists
 }

--- a/examples/standalone_example/main.tf
+++ b/examples/standalone_example/main.tf
@@ -43,7 +43,6 @@ module "notebook" {
   project_trusted_kms       = var.project_trusted_kms
   trusted_private_network   = var.trusted_private_network
   trusted_private_subnet    = var.trusted_private_subnet
-  caip_users                = var.caip_users
   confidential_groups       = var.confidential_groups
   trusted_scientists        = var.trusted_scientists
 }

--- a/examples/standalone_example/variables.tf
+++ b/examples/standalone_example/variables.tf
@@ -50,17 +50,17 @@ variable "trusted_private_subnet" {
 }
 
 variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook."
+  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
   type        = list(string)
 }
 
-variable "confid_users" {
+variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users."
+  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
   type        = list(string)
 }
 

--- a/examples/standalone_example/variables.tf
+++ b/examples/standalone_example/variables.tf
@@ -49,18 +49,13 @@ variable "trusted_private_subnet" {
   type        = string
 }
 
-variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
-  type        = list(string)
-}
-
 variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
+  description = "The list of trusted users."
   type        = list(string)
 }
 

--- a/iam.tf
+++ b/iam.tf
@@ -15,7 +15,7 @@
  */
 
 # The notebook-compute-sa provides the underlying policies that the compute uses to access other resources
-# within the project for the data scientist.  
+# within the project for the data scientist.
 #
 # The data scientist should not be given the ability to become an SA.  Instead, they should be given
 # OSLogin User role and SSH into the notebook
@@ -86,7 +86,7 @@ resource "google_bigquery_dataset_iam_binding" "iam_bq_confid_viewer" {
   role       = format("projects/%s/roles/%s", var.project_trusted_data, module.role_restricted_data_viewer.custom_role_id)
   project    = var.project_trusted_data
 
-  members = concat(var.confid_users, ["serviceAccount:${google_service_account.sa_p_notebook_compute.email}"])
+  members = concat(var.confidential_groups, ["serviceAccount:${google_service_account.sa_p_notebook_compute.email}"])
 }
 
 #=====================================================================
@@ -118,7 +118,7 @@ data "google_project" "project_analytics" {
 #=====================================================================
 # Grant access to KMS to support CMEK for data services
 # This is fine grain limited to only the single key.
-# 
+#
 # config_users: a group with trusted scientists identities.  Add users in this group.
 # google_managed_members: need the AI Platform's service's identity granted access.  Do not add identities to this group
 #=====================================================================
@@ -134,7 +134,7 @@ resource "google_kms_crypto_key_iam_binding" "iam_p_bq_sa_confid" {
       "serviceAccount:service-${data.google_project.project_analytics.number}@compute-system.iam.gserviceaccount.com",
     ],
     ["serviceAccount:${google_service_account.sa_p_notebook_compute.email}"],
-    var.confid_users
+    var.confidential_groups
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -72,9 +72,9 @@ resource "google_storage_bucket_object" "postscript" {
 resource "google_project_iam_member" "notebook_caip_user_iam" {
   project  = var.project_trusted_analytics
   role     = "roles/notebooks.viewer"
-  for_each = toset(var.caip_users)
+  for_each = toset(var.trusted_scientists)
 
-  member = "user:${each.value}"
+  member = each.value
 }
 
 # Creates a trusted notebook per relevant user that has file
@@ -83,10 +83,10 @@ resource "google_project_iam_member" "notebook_caip_user_iam" {
 resource "google_notebooks_instance" "caip_nbk_p_trusted" {
   provider        = google-beta
   project         = var.project_trusted_analytics
-  for_each        = toset(var.caip_users)
+  for_each        = toset(var.trusted_scientists)
   service_account = google_service_account.sa_p_notebook_compute.email
 
-  name         = format("caip-nbk-%s-%s-%s", var.notebook_name_prefix, split("@", each.value)[0], random_string.random_name.result)
+  name         = format("caip-nbk-%s-%s-%s", var.notebook_name_prefix, split("@", split(":", each.value)[1])[0], random_string.random_name.result)
   location     = var.zone
   machine_type = "n1-standard-1"
 

--- a/test/fixtures/standalone_example/main.tf
+++ b/test/fixtures/standalone_example/main.tf
@@ -26,7 +26,7 @@ module "standalone_example" {
   trusted_private_network   = var.trusted_private_network
   trusted_private_subnet    = var.trusted_private_subnet
   caip_users                = var.caip_users
-  confid_users              = var.confid_users
+  confidential_groups       = var.confidential_groups
   trusted_scientists        = var.trusted_scientists
   dataset_id                = var.dataset_id
 }

--- a/test/fixtures/standalone_example/main.tf
+++ b/test/fixtures/standalone_example/main.tf
@@ -25,7 +25,6 @@ module "standalone_example" {
   project_trusted_kms       = var.project_trusted_kms
   trusted_private_network   = var.trusted_private_network
   trusted_private_subnet    = var.trusted_private_subnet
-  caip_users                = var.caip_users
   confidential_groups       = var.confidential_groups
   trusted_scientists        = var.trusted_scientists
   dataset_id                = var.dataset_id

--- a/test/fixtures/standalone_example/variables.tf
+++ b/test/fixtures/standalone_example/variables.tf
@@ -50,17 +50,17 @@ variable "trusted_private_subnet" {
 }
 
 variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook."
+  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
   type        = list(string)
 }
 
-variable "confid_users" {
+variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users."
+  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
   type        = list(string)
 }
 

--- a/test/fixtures/standalone_example/variables.tf
+++ b/test/fixtures/standalone_example/variables.tf
@@ -49,18 +49,13 @@ variable "trusted_private_subnet" {
   type        = string
 }
 
-variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
-  type        = list(string)
-}
-
 variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
+  description = "The list of trusted users."
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -77,18 +77,13 @@ variable "trusted_private_subnet" {
   type        = string
 }
 
-variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
-  type        = list(string)
-}
-
 variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
+  description = "The list of trusted users."
   type        = list(string)
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,17 +78,17 @@ variable "trusted_private_subnet" {
 }
 
 variable "caip_users" {
-  description = "The list of users that need an AI Platform Notebook."
+  description = "The list of users that need an AI Platform Notebook. In this blueprint, there are the same as the trusted users."
   type        = list(string)
 }
 
-variable "confid_users" {
+variable "confidential_groups" {
   description = "The list of groups allowed to access PII data."
   type        = list(string)
 }
 
 variable "trusted_scientists" {
-  description = "The list of trusted users."
+  description = "The list of trusted users. In this blueprint, they are the same as the caip_users who have their own notebooks."
   type        = list(string)
 }
 


### PR DESCRIPTION
- Renames variables for groups instead of users if related to groups
- Renames groups to match the names in guide
- Merge caip_users and trusted_scientists into one variable