### PR TITLE
fix: support identity characters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,7 +86,8 @@ resource "google_notebooks_instance" "caip_nbk_p_trusted" {
   for_each        = toset(var.trusted_scientists)
   service_account = google_service_account.sa_p_notebook_compute.email
 
-  name         = format("caip-nbk-%s-%s-%s", var.notebook_name_prefix, split("@", split(":", each.value)[1])[0], random_string.random_name.result)
+  # replace characters with dash (-) from user identities not supported in GCE instance names such as period (.), apostrophe ('), underscore (_)
+  name         = format("caip-nbk-%s-%s-%s", var.notebook_name_prefix, split("@", replace(each.value, "/[.'_]+/", "-"))[0], random_string.random_name.result)
   location     = var.zone
   machine_type = "n1-standard-1"
 


### PR DESCRIPTION
handle the various characters found in a user identity that does not
work in a GCE instance name

fixes #53